### PR TITLE
Allow specifying versions with operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ import django
 print(django.__version__)  # 2.0.3
 ```
 
+For loose version specification use comparison operator as with regular pip 
+command
+
+```python
+import pypi
+
+pypi.install('Django', '>=2.0.1')
+pypi.install('Django', '<1.9')
+# all <=, <, ==, >, >= operators works as well
+
+```
+
 # License
 
 GNU GPLv3.

--- a/pypi.py
+++ b/pypi.py
@@ -6,14 +6,21 @@ import sys
 
 def install(pkgname, version=None):
     cmd = [sys.executable, '-m', 'pip', 'install']
+    version_specs = ('>=', '>', '<=', '<', '==')
     if version:
-        cmd.append('{}=={}'.format(pkgname, version))
+        version_spec = '=='
+        if any([str.startswith(version, v) for v in version_specs]):
+            version_spec, version = [
+                (version[:len(v)], version[len(v):]) for v in version_specs
+                if version.startswith(v)
+            ][0]
+        cmd.append('{}{}{}'.format(pkgname, version_spec, version))
     else:
         cmd.append(pkgname)
     subprocess.check_call(
         cmd,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        # stdout=subprocess.DEVNULL,
+        # stderr=subprocess.DEVNULL,
     )
 
 

--- a/pypi.py
+++ b/pypi.py
@@ -19,8 +19,8 @@ def install(pkgname, version=None):
         cmd.append(pkgname)
     subprocess.check_call(
         cmd,
-        # stdout=subprocess.DEVNULL,
-        # stderr=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
     )
 
 


### PR DESCRIPTION
## Rationale
Allow specifying not only fixed version when exact version is not known.